### PR TITLE
closes #3 ルートページを空で作成

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,12 @@ func Root(c web.C, w http.ResponseWriter, r *http.Request) {
 	if result {
 		fmt.Printf("current_user: %+v\n", *current_user)
 	}
+	tpl, err := pongo2.DefaultSet.FromFile("views/home.html.tpl")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	tpl.ExecuteWriter(pongo2.Context{"title": "Fascia"}, w)
 }
 
 func SignIn(c web.C, w http.ResponseWriter, r *http.Request) {

--- a/views/home.html.tpl
+++ b/views/home.html.tpl
@@ -1,0 +1,7 @@
+{% extends "layout.html.tpl" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+
+{% endblock %}


### PR DESCRIPTION
テンプレートをかませただけの空ページを作りました．
この先はデザインと歩調を合わせてテンプレートの内容を埋める必要があります．