### PR TITLE
closes #49 githubのEmailをログイン時に適切に処理する

### DIFF
--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -25,7 +25,7 @@ type JsonError struct {
 var githubOauthConf = &oauth2.Config{
 	ClientID: os.Getenv("CLIENT_ID"),
 	ClientSecret: os.Getenv("CLIENT_SECRET"),
-	Scopes: []string{"repo", "write:repo_hook"},
+	Scopes: []string{"repo", "write:repo_hook", "user:email"},
 	Endpoint: github.Endpoint,
 }
 

--- a/controllers/registrations_controller.go
+++ b/controllers/registrations_controller.go
@@ -58,7 +58,7 @@ func (u *Registrations)Registration(c web.C, w http.ResponseWriter, r *http.Requ
 
 	if signUpForm.Password == signUpForm.PasswordConfirm {
 		// login
-		res := userModel.Registration(signUpForm.Email, signUpForm.Password)
+		_, res := userModel.Registration(signUpForm.Email, signUpForm.Password)
 		if !res {
 			http.Redirect(w, r, "/sign_up", 302)
 		} else {

--- a/models/project/project_test.go
+++ b/models/project/project_test.go
@@ -37,17 +37,10 @@ var _ = Describe("ProjectSave", func() {
 	JustBeforeEach(func() {
 		email := "save@example.com"
 		password := "hogehoge"
-		_ = user.Registration(email, password)
+		uid, _ = user.Registration(email, password)
 		mydb := &db.Database{}
 		var database db.DB = mydb
 		table = database.Init()
-		rows, _ := table.Query("select id from users where email = ?;", email)
-		for rows.Next() {
-			err := rows.Scan(&uid)
-			if err != nil {
-				panic(err.Error())
-			}
-		}
 		newProject = NewProject(0, uid, "title")
 	})
 

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -93,7 +93,7 @@ func CurrentUser(userID int64) (*UserStruct, error) {
 	return &user, nil
 }
 
-func Registration(email string, password string) bool {
+func Registration(email string, password string) (int64, bool) {
 	objectDB := &db.Database{}
 	var interfaceDB db.DB = objectDB
 	table := interfaceDB.Init()
@@ -101,15 +101,15 @@ func Registration(email string, password string) bool {
 
 	hashPassword, err := hashPassword(password)
 	if err != nil {
-		return false
+		return 0, false
 	}
-	_, err = table.Exec("insert into users (email, password, created_at) values (?, ?, ?)", email, hashPassword, time.Now())
+	result, err := table.Exec("insert into users (email, password, created_at) values (?, ?, ?)", email, hashPassword, time.Now())
 	if err != nil {
 		fmt.Printf("mysql connect error: %v \n", err)
-		return false
+		return 0, false
 	}
-
-	return true
+	id, _ := result.LastInsertId()
+	return id, true
 }
 
 func Login(userEmail string, userPassword string) (*UserStruct, error) {

--- a/models/user/user_test.go
+++ b/models/user/user_test.go
@@ -163,7 +163,7 @@ var _ = Describe("User", func() {
 			tc := oauth2.NewClient(oauth2.NoContext, ts)
 			client := github.NewClient(tc)
 			githubUser, _, _ := client.Users.Get("")
-			result = newUser.CreateGithubUser(token, githubUser)
+			result = newUser.CreateGithubUser(token, githubUser, "create_github_user@example.com")
 		})
 		It("ユーザが登録されること", func() {
 			mydb := &db.Database{}


### PR DESCRIPTION
- [x] githubからEmailを取得して登録する
- [x] 既に登録済みユーザがgithub登録しようとしたら，勝手に関連付ける（ただし，パスワード等が入力済みの場合は上書きしない）
- [x] 既にgithub登録済みのユーザで新規登録しようとしたらエラーにしておく