### PR TITLE
closes #104 githubとの同期メソッドを作る

### DIFF
--- a/controllers/lists_controller_test.go
+++ b/controllers/lists_controller_test.go
@@ -116,8 +116,9 @@ var _ = Describe("ListsController", func() {
 			con, _ := ioutil.ReadAll(res.Body)
 			json.Unmarshal(con, &contents)
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
-			Expect(contents[0].Title.String).To(Equal("list1"))
-			Expect(contents[1].Title.String).To(Equal("list2"))
+			// 初期リストが入るようになったのでそれ以降
+			Expect(contents[3].Title.String).To(Equal("list1"))
+			Expect(contents[4].Title.String).To(Equal("list2"))
 		})
 	})
 })

--- a/controllers/projects_controller.go
+++ b/controllers/projects_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	listModel "../models/list"
 	projectModel "../models/project"
 	repositoryModel "../models/repository"
 	"encoding/json"
@@ -79,9 +80,22 @@ func (u *Projects) Create(c web.C, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "save failed", 500)
 		return
 	}
+
+	// 初期リストを作っておく
+	todo := listModel.NewList(0, project.Id, current_user.Id, "ToDo", "ff0000")
+	inprogress := listModel.NewList(0, project.Id, current_user.Id, "InProgress", "0000ff")
+	done := listModel.NewList(0, project.Id, current_user.Id, "Done", "0a0a0a")
 	if newProjectForm.RepositoryID != 0 {
 		repository := repositoryModel.NewRepository(0, project.Id, newProjectForm.RepositoryID, newProjectForm.RepositoryOwner, newProjectForm.RepositoryName)
 		repository.Save()
+		todo.Save(repository, &current_user.OauthToken)
+		inprogress.Save(repository, &current_user.OauthToken)
+		done.Save(repository, &current_user.OauthToken)
+	} else {
+		todo.Save(nil, nil)
+		inprogress.Save(nil, nil)
+		done.Save(nil, nil)
 	}
+
 	encoder.Encode(*project)
 }

--- a/controllers/projects_controller.go
+++ b/controllers/projects_controller.go
@@ -119,7 +119,11 @@ func (u *Projects) FetchGithub(c web.C, w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "failed fetch github", 500)
 		return
 	} else {
-		encoder.Encode("success")
+		lists := project.Lists()
+		for _, l := range lists {
+			l.ListTasks = l.Tasks()
+		}
+		encoder.Encode(lists)
 		return
 	}
 }

--- a/controllers/projects_controller.go
+++ b/controllers/projects_controller.go
@@ -99,3 +99,27 @@ func (u *Projects) Create(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	encoder.Encode(*project)
 }
+
+func (u *Projects) FetchGithub(c web.C, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	current_user, result := LoginRequired(r)
+	encoder := json.NewEncoder(w)
+	if !result {
+		http.Error(w, "not logined", 401)
+		return
+	}
+	projectID, _ := strconv.ParseInt(c.URLParams["project_id"], 10, 64)
+	project := projectModel.FindProject(projectID)
+	if project == nil && project.UserId.Int64 != current_user.Id {
+		http.Error(w, "project not found", 404)
+		return
+	}
+	_, err := project.FetchGithub()
+	if err != nil {
+		http.Error(w, "failed fetch github", 500)
+		return
+	} else {
+		encoder.Encode("success")
+		return
+	}
+}

--- a/controllers/projects_controller.go
+++ b/controllers/projects_controller.go
@@ -116,7 +116,7 @@ func (u *Projects) FetchGithub(c web.C, w http.ResponseWriter, r *http.Request) 
 	}
 	_, err := project.FetchGithub()
 	if err != nil {
-		http.Error(w, "failed fetch github", 500)
+		http.Error(w, err.Error(), 500)
 		return
 	} else {
 		lists := project.Lists()

--- a/controllers/tasks_controller_test.go
+++ b/controllers/tasks_controller_test.go
@@ -132,8 +132,9 @@ var _ = Describe("TasksController", func() {
 			con, _ := ioutil.ReadAll(res.Body)
 			json.Unmarshal(con, &contents)
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
-			Expect(contents[0].ListTasks).To(BeEmpty())
-			Expect(contents[1].ListTasks[0].Id).To(Equal(newTask.Id))
+			// 初期リストが入るようになったのでそれ以降
+			Expect(contents[3].ListTasks).To(BeEmpty())
+			Expect(contents[4].ListTasks[0].Id).To(Equal(newTask.Id))
 		})
 	})
 })

--- a/frontend/javascripts/actions/ListAction.js
+++ b/frontend/javascripts/actions/ListAction.js
@@ -393,3 +393,36 @@ export function taskDragOver(ev) {
     taskDragToList: targetList
   };
 }
+
+export const REQUEST_FETCH_GITHUB = "REQUEST_FETCH_GITHUB";
+function requestFetchGithub() {
+  return {
+    type: REQUEST_FETCH_GITHUB
+  };
+}
+
+export const RECEIVE_FETCH_GITHUB = "RECEIVE_FETCH_GITHUB";
+function receiveFetchGithub(lists) {
+  return {
+    type: RECEIVE_FETCH_GITHUB,
+    lists: lists
+  };
+}
+
+export const FETCH_PROJECT_GITHUB = "FETCH_PROJECT_GITHUB";
+export function fetchProjectGithub(projectId) {
+  return dispatch => {
+    dispatch(requestFetchGithub());
+    return Request
+      .post(`/projects/${projectId}/fetch_github`)
+      .end((err, res) => {
+        if (res.ok) {
+          dispatch(receiveFetchGithub(res.body));
+        } else if(res.unauthorized) {
+          dispatch(unauthorized());
+        } else {
+          dispatch(serverError());
+        }
+      });
+  };
+}

--- a/frontend/javascripts/actions/ProjectAction.js
+++ b/frontend/javascripts/actions/ProjectAction.js
@@ -130,11 +130,16 @@ function receiveCreateProject(id, userId, title, description) {
 export function fetchCreateProject(title, description, repository) {
   return dispatch => {
     dispatch(requestCreateProject());
-    console.log(repository);
+    var repositoryId, repositoryOwner, repositoryName;
+    if (repository != null) {
+      repositoryId = repository.id;
+      repositoryOwner = repository.owner.login;
+      repositoryName = repository.name;
+    }
     return Request
       .post('/projects')
       .type('form')
-      .send({title: title, description: description, repositoryId: repository.id, repositoryOwner: repository.owner.login, repositoryName: repository.name})
+      .send({title: title, description: description, repositoryId: repositoryId, repositoryOwner: repositoryOwner, repositoryName: repositoryName})
       .end((err, res)=> {
         if (res.ok) {
           dispatch(receiveCreateProject(res.body.Id, res.body.UserId, res.body.Title, res.body.Description));

--- a/frontend/javascripts/components/ListView.jsx
+++ b/frontend/javascripts/components/ListView.jsx
@@ -108,6 +108,7 @@ export default class ListView extends React.Component {
           </div>
         </Modal>
         <div className="title-wrapper">
+          <div className="project-operation"><i className="fa fa-repeat" onClick={e => this.props.fetchProjectGithub(this.props.params.projectId)}></i></div>
           <h3 className="project-title">{project != null ? project.Title : ''}</h3>
         </div>
         <div className="items">

--- a/frontend/javascripts/components/ListView.jsx
+++ b/frontend/javascripts/components/ListView.jsx
@@ -32,9 +32,11 @@ export default class ListView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    setTimeout(() => {
-      this.props.closeFlash()
-    }, 3000);
+    if (this.props.ListReducer.error != null) {
+      setTimeout(() => {
+        this.props.closeFlash()
+      }, 3000);
+    }
   }
 
   render() {

--- a/frontend/javascripts/components/ProjectView.jsx
+++ b/frontend/javascripts/components/ProjectView.jsx
@@ -36,9 +36,11 @@ class ProjectView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    setTimeout(() => {
-      this.props.closeFlash()
-    }, 3000);
+    if (this.props.ProjectReducer.error != null) {
+      setTimeout(() => {
+        this.props.closeFlash()
+      }, 3000);
+    }
   }
 
   render() {

--- a/frontend/javascripts/reducers/ListReducer.js
+++ b/frontend/javascripts/reducers/ListReducer.js
@@ -81,6 +81,7 @@ export default function ListReducer(state = initState, action) {
       newTask: newTask
     });
   case listActions.RECEIVE_LISTS:
+  case listActions.RECEIVE_FETCH_GITHUB:
   case listActions.RECEIVE_MOVE_TASK:
     var lists;
     if (action.lists == null) {

--- a/frontend/stylesheets/lists/lists.scss
+++ b/frontend/stylesheets/lists/lists.scss
@@ -6,6 +6,12 @@
       margin: 5px;
       color: rgb(0, 120, 230);
     }
+    .project-operation {
+      float: right;
+      margin-right: 30px;
+      color: rgb(0, 120, 213);
+      cursor: pointer;
+    }
   }
   .items {
     vertical-align: top;

--- a/models/list/list.go
+++ b/models/list/list.go
@@ -94,11 +94,8 @@ func (u *ListStruct) Save(repo *repository.RepositoryStruct, OauthToken *sql.Nul
 				return false
 			}
 		} else {
-			// createしようとしたときに存在している場合，それはgithub側からの同期が失敗しているから
-			// だとするならここは素直にエラーにして，同期処理でエラーが出ないようにしておかないと連鎖バグになる可能性が高い
+			// createしようとしたときに存在している場合，それはあまり気にしなくて良い．むしろこれで同等の状態になる
 			fmt.Printf("github label already exist\n")
-			tx.Rollback()
-			return false
 		}
 	}
 	tx.Commit()

--- a/modules/hub/hub.go
+++ b/modules/hub/hub.go
@@ -132,3 +132,25 @@ func ReplaceLabelsForIssue(token string, repo *repository.RepositoryStruct, numb
 	fmt.Printf("github issue replaced labels: %+v\n", labels)
 	return true
 }
+
+func GetGithubIssues(token string, repo *repository.RepositoryStruct) ([]github.Issue, []github.Issue) {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	client := github.NewClient(tc)
+
+	openIssueOption := github.IssueListByRepoOptions{
+		State: "open",
+	}
+	closedIssueOption := github.IssueListByRepoOptions{
+		State: "closed",
+	}
+	opneIssues, _, err := client.Issues.ListByRepo(repo.Owner.String, repo.Name.String, &openIssueOption)
+	if err != nil {
+		panic(err.Error())
+	}
+	closedIssues, _, err := client.Issues.ListByRepo(repo.Owner.String, repo.Name.String, &closedIssueOption)
+
+	return opneIssues, closedIssues
+}

--- a/server.go
+++ b/server.go
@@ -29,6 +29,7 @@ func Routes(m *web.Mux) {
 	m.Post("/projects", controllers.CallController(&controllers.Projects{}, "Create"))
 	m.Get("/projects", controllers.CallController(&controllers.Projects{}, "Index"))
 	m.Get("/projects/:project_id/show", controllers.CallController(&controllers.Projects{}, "Show"))
+	m.Post("/projects/:project_id/fetch_github", controllers.CallController(&controllers.Projects{}, "FetchGithub"))
 	m.Get("/github/repositories", controllers.CallController(&controllers.Github{}, "Repositories"))
 	m.Get("/projects/:project_id/lists", controllers.CallController(&controllers.Lists{}, "Index"))
 	m.Post("/projects/:project_id/lists", controllers.CallController(&controllers.Lists{}, "Create"))


### PR DESCRIPTION
issue-taskについてはすべて同期したい．fasciaとgithub，2つのものをマージしたものが最終的に両方に存在するようにしたい．
label-listについては，すべて同期するつもりはなく，あくまでfasciaは必要なものだけを作り，それをgithub側に反映するだけ．もちろんgithub側に存在すればそれを使いまわす．

- [x] まず，fascia側で初期リスト（ラベル）を決めて，それを作ってしまう．ToDo，InProgress，Doneの3種
- [x] 同期アクションを作り，github側のlableとissueを取得する
- [x] fascia側で持っているラベルがついていないissueについては，taskとして同期したときに全部ToDoに放り込む．closeのやつはDoneに放り込む．
- [x] taskの移動時に，移動ラベルのlabel同期はしてもいいけど，fascia側にないラベルについては触れずに行えるようにしておく．
- [x] issueに紐づくラベルの不一致は基本的にgithub側を正として，それに従うようにする
- [x] issueとtaskの不一致については，fascia側が持っていないtaskについては問答無用で同期する．その後，fasciaしか持っていないtaskをissue側に同期する．

