### PR TITLE
refs #161 API側で初期リストの編集を禁止する

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func Element(elem string) interface{} {
+	env := os.Getenv("GOJIENV")
+	root := os.Getenv("GOJIROOT")
+	path := filepath.Join(root, "config/settings.yml")
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	m := make(map[interface{}]interface{})
+	err = yaml.Unmarshal(buf, &m)
+	if err != nil {
+		panic(err)
+	}
+	return m[env].(map[interface{}]interface{})[elem]
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,15 @@
+development:
+  init_list:
+    todo: "ToDo"
+    inprogress: "InProgress"
+    done: "Done"
+test:
+  init_list:
+    todo: "ToDo"
+    inprogress: "InProgress"
+    done: "Done"
+production:
+  init_list:
+    todo: "ToDo"
+    inprogress: "InProgress"
+    done: "Done"

--- a/controllers/projects_controller.go
+++ b/controllers/projects_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"../config"
 	listModel "../models/list"
 	"../models/list_option"
 	projectModel "../models/project"
@@ -114,9 +115,9 @@ func (u *Projects) Create(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	// 初期リストを作っておく
 	// TODO: ここエラーハンドリングしたほうがいい
-	todo := listModel.NewList(0, project.Id, current_user.Id, "ToDo", "ff0000", sql.NullInt64{})
-	inprogress := listModel.NewList(0, project.Id, current_user.Id, "InProgress", "0000ff", sql.NullInt64{})
-	done := listModel.NewList(0, project.Id, current_user.Id, "Done", "0a0a0a", sql.NullInt64{Int64: closeListOption.Id, Valid: true})
+	todo := listModel.NewList(0, project.Id, current_user.Id, config.Element("init_list").(map[interface{}]interface{})["todo"].(string), "ff0000", sql.NullInt64{})
+	inprogress := listModel.NewList(0, project.Id, current_user.Id, config.Element("init_list").(map[interface{}]interface{})["inprogress"].(string), "0000ff", sql.NullInt64{})
+	done := listModel.NewList(0, project.Id, current_user.Id, config.Element("init_list").(map[interface{}]interface{})["done"].(string), "0a0a0a", sql.NullInt64{Int64: closeListOption.Id, Valid: true})
 	if newProjectForm.RepositoryID != 0 {
 		repository := repositoryModel.NewRepository(0, project.Id, newProjectForm.RepositoryID, newProjectForm.RepositoryOwner, newProjectForm.RepositoryName)
 		repository.Save()

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"../../config"
 	"../../modules/hub"
 	"../../modules/logging"
 	"../db"
@@ -146,9 +147,9 @@ func (u *ProjectStruct) FetchGithub() (bool, error) {
 	var openList, closedList *list.ListStruct
 	for _, list := range u.Lists() {
 		// openとcloseのリストは用意しておく
-		if list.Title.Valid && list.Title.String == "ToDo" {
+		if list.Title.Valid && list.Title.String == config.Element("init_list").(map[interface{}]interface{})["todo"].(string) {
 			openList = list
-		} else if list.Title.Valid && list.Title.String == "Done" {
+		} else if list.Title.Valid && list.Title.String == config.Element("init_list").(map[interface{}]interface{})["done"].(string) {
 			closedList = list
 		}
 	}


### PR DESCRIPTION
configを導入し，そこで初期リストを管理する．
今まで初期リスト名を直打ちしていた部分をconfigに書き換える．